### PR TITLE
Add toggle power button for monitor

### DIFF
--- a/backend/ddcci_plasmoid_backend/__main__.py
+++ b/backend/ddcci_plasmoid_backend/__main__.py
@@ -121,6 +121,21 @@ def main():
             except subprocess.CalledProcessError as err:
                 logger.debug(err)
                 handle_error(err)
+        elif arguments['command'] == 'toggle-power':
+            bus_id = arguments['bus']
+            try:
+                ddcci.toggle_power(bus_id)
+                print(json.dumps({
+                    'command': 'toggle-power',
+                    'value': {
+                        'bus_id': bus_id,
+                    }
+                }))
+            except subprocess.CalledProcessError as err:
+                logger.debug(err)
+                handle_error(err)
+
+
 
     sys.exit(0)
 

--- a/backend/ddcci_plasmoid_backend/ddcci.py
+++ b/backend/ddcci_plasmoid_backend/ddcci.py
@@ -56,7 +56,8 @@ async def detect():
         result = await async_subprocess_wrapper(
             f'ddcutil getvcp --bus {bus_id} --brief {brightness_feature_code:x}')
 
-        _, _, _, display_brightness_raw, _ = result['stdout'].split(' ')
+        # In case of an partial error, first few lines of stdout are the error message, and the last non-empty line is the actual result
+        _, _, _, display_brightness_raw, _ = result['stdout'].split("\n")[-2].split(' ')
 
         return {
             'id': display_id,

--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -289,6 +289,7 @@ Item {
                       }
                       onClicked: {
                           executable.exec(plasmoid.configuration.executable + ` toggle-power ${bus_id}`)
+                          is_on = !is_on
                       }
                   }
                 }

--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -70,7 +70,7 @@ Item {
             commandSuccess(cmd);
         }
         property string command: `${plasmoid.configuration.executable} detect`
-        // add the meaningless variable `ONCE=1` in front so we can differentiate this one-off call from regular calls and disconnect it 
+        // add the meaningless variable `ONCE=1` in front so we can differentiate this one-off call from regular calls and disconnect it
         property string oneoffCommand: `ONCE=1 ${command}`
         function start() {
             connectSource(command);
@@ -195,7 +195,7 @@ Item {
                 visible: monitorModel.count > 0
 
                 Layout.alignment: Qt.AlignHCenter
-                columns: 3
+                columns: 4
                 rows: monitorModel.count
                 flow: GridLayout.TopToBottom
                 columnSpacing: PlasmaCore.Units.gridUnit
@@ -267,7 +267,7 @@ Item {
                         id: percentageLabel
                         horizontalAlignment: Qt.AlignRight
 
-                        text: brightness + '%'
+                        text: brightness + '% (' + (is_on ? i18n('On') : i18n('Off')) +')'
 
                         Layout.minimumWidth: percentageMetrics.advanceWidth
                         TextMetrics {
@@ -276,6 +276,21 @@ Item {
                             text: '100%'
                         }
                     }
+                }
+
+                Repeater {
+                    model: monitorModel
+                    delegate: PlasmaComponents.ToolButton {
+                      Layout.alignment: Qt.AlignRight
+
+                      icon.name: 'system-shutdown-symbolic'
+                      PlasmaComponents.ToolTip {
+                          text: i18n("Toggle monitor power")
+                      }
+                      onClicked: {
+                          executable.exec(plasmoid.configuration.executable + ` toggle-power ${bus_id}`)
+                      }
+                  }
                 }
             }
 

--- a/plasmoid/translate/template.pot
+++ b/plasmoid/translate/template.pot
@@ -44,3 +44,15 @@ msgstr ""
 #: ../contents/ui/main.qml
 msgid "Refresh monitors"
 msgstr ""
+
+#: ../contents/ui/main.qml
+msgid "Toggle monitor power"
+msgstr ""
+
+#: ../contents/ui/main.qml
+msgid "On"
+msgstr ""
+
+#: ../contents/ui/main.qml
+msgid "Off"
+msgstr ""


### PR DESCRIPTION
Added button to enable monitor turning on/off, depending on current state. Also, showing currrent power state next to brightness.

Ignore errors from ddcutil command for not perfect ddcci installations (ddcutils first prints a lot of error lines, and then actual output on the last line)