### PR TITLE
Workaround for high resolution mouse wheel

### DIFF
--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -244,6 +244,7 @@ PlasmoidItem {
                         onMoved: () => {
                             // Should also be locked during mouse wheel scrolling.
                             valuesLock = true
+                            value = Math.round(value)
                             brightness = value
 
                             // Handle mouse wheel debounce only when the slider is not pressed.


### PR DESCRIPTION
On Debian 12 and KDE Plasma 5.27.5, the high resolution mouse wheel (for me, it's Logitech M720) may cause the value to be a non-integer number.

This may be a bug, but considering that the backend only supports integers, this should be works.